### PR TITLE
issues/50 fix: hotfix 登入網址錯誤

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("projects/", include("projects.urls")),
     path("faqs/", include("faqs.urls")),
     path("users/", include("users.urls")),
-    path("accounts/", include("allauth.urls")),
     path("accounts/", include("accounts.urls")),
+    path("accounts/", include("allauth.urls")),
     path('comments/', include("comments.urls")),
 ]


### PR DESCRIPTION
#50
登入頁面網址順序錯誤造成登入頁面不正常顯示

修正core.url
accounts.url及allauth.urls的順序

