### PR TITLE
issues/83 feat: 安裝Font Awesome

### DIFF
--- a/frontends/scripts/app.js
+++ b/frontends/scripts/app.js
@@ -5,3 +5,14 @@ window.Alpine = Alpine;
 window.htmx = htmx;
 
 Alpine.start();
+
+// Font Awesome 引入
+import { library, dom } from "@fortawesome/fontawesome-svg-core";
+import { faSpinner, faHouse, faHeart } from "@fortawesome/free-solid-svg-icons"; // 引入 spinner 圖標
+import "@fortawesome/fontawesome-svg-core/styles.css"; // 引入基本樣式
+
+// 將圖標添加到庫中
+library.add(faSpinner, faHouse, faHeart);
+
+// 自動掃描 DOM 並渲染圖標
+dom.watch();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
         "htmx.org": "^1.9.12"
       },
       "devDependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "autoprefixer": "^10.4.20",
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
@@ -575,6 +578,52 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "dev": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "dev": true,
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "scripts": {
-    "dev": "esbuild frontends/scripts/app.js --bundle --outfile=static/scripts/app.js --watch",
+    "dev": "esbuild frontends/scripts/app.js --bundle --outfile=static/scripts/app.js --watch --platform=browser",
     "build": "esbuild frontends/scripts/app.js --bundle --outfile=static/scripts/app.js",
     "css": "tailwindcss -i ./frontends/styles/app.css -o ./static/styles/app.css --watch",
     "commit": "cz"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "autoprefixer": "^10.4.20",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
1. 安裝font awesome套件
2. 理解使用方式

使用步驟如下，每一個icon都需要import到fontend/scripts/app.js

1. 修改名字來源，依照下圖紅色框，將fa後面第一個字改成大寫
<img width="561" alt="截圖 2024-12-30 晚上7 05 57" src="https://github.com/user-attachments/assets/e4c6c033-5af1-4838-acfb-c02addad0c1a" />

2. 修改fontend/scripts/app.js，將步驟一的取得的名字，如紅色框進行增加
<img width="844" alt="截圖 2024-12-30 晚上7 03 42" src="https://github.com/user-attachments/assets/bc4ade25-8b10-4fcd-a3a9-5e3626ee5579" />




功能展示

https://github.com/user-attachments/assets/6f8a783e-ba33-4f9a-9085-75c566840621

安裝流程可參考下列文件
https://ianyang1106.github.io/Ian_blog/posts/fontawesome%E5%AE%89%E8%A3%9D/

