### PR TITLE
issues/149: chore: change Google login bg color, add Font Awesome

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -24,9 +24,9 @@
           <a
             href="/accounts/google/login/"
             class="btn w-full"
-            style="background-color: #4285f4; color: white"
+            style="background-color: #85cacc; color: white"
           >
-            <i class="fab fa-google mr-2"></i>
+            <i class="fa-brands fa-google"></i>
             使用 Google 帳號登入
           </a>
         </div>

--- a/accounts/templates/accounts/register.html
+++ b/accounts/templates/accounts/register.html
@@ -24,9 +24,9 @@
           <a
             href="/accounts/google/login/"
             class="btn w-full"
-            style="background-color: #4285f4; color: white"
+            style="background-color: #85cacc; color: white"
           >
-            <i class="fab fa-google mr-2"></i>
+            <i class="fa-brands fa-google"></i>
             使用 Google 帳號註冊
           </a>
         </div>

--- a/frontends/scripts/fontawesome.js
+++ b/frontends/scripts/fontawesome.js
@@ -44,6 +44,7 @@ import {
 
 
 } from "@fortawesome/free-solid-svg-icons";
+import { faGoogle } from "@fortawesome/free-brands-svg-icons";
 
 // 添加圖示到庫中
 library.add(
@@ -87,7 +88,7 @@ library.add(
   faExclamationTriangle,
   faBars,
   faSearch,
-
+  faGoogle
 );
 
 // 自動掃描 DOM 並渲染圖標

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
         "alpinejs": "^3.14.7",
         "chart.js": "^4.4.7",
@@ -588,7 +589,6 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
       "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -610,6 +610,18 @@
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "tailwindcss": "^3.4.16"
   },
   "dependencies": {
+    "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
     "alpinejs": "^3.14.7",
-    "htmx.org": "^1.9.12",
-    "sortablejs": "^1.15.6",
     "chart.js": "^4.4.7",
-    "chartjs-plugin-datalabels": "^2.2.0"
+    "chartjs-plugin-datalabels": "^2.2.0",
+    "htmx.org": "^1.9.12",
+    "sortablejs": "^1.15.6"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
#149 

將google登入按鈕改成主題底色並用Font Awesome 加上google logo

前端有新增"@fortawesome/free-brands-svg-icons": "^6.7.2", 
**記得npm install**

![image](https://github.com/user-attachments/assets/25323ea0-bca4-477d-a2b4-db9ce0864d33)
