### PR TITLE
Issues/163 fix: 將所有頁面的user.username改成profile.name

### DIFF
--- a/comments/templates/comments/comment_item.html
+++ b/comments/templates/comments/comment_item.html
@@ -1,7 +1,7 @@
 <div class="comment-item" id="comment-{{ comment.slug }}">
   <div class="mb-4">
     <p class="text-gray-800">
-      <strong>{{ comment.account.username }}</strong>
+      <strong>{{ comment.account.profile.name }}</strong>
       : {{ comment.content }}
     </p>
     <small class="text-gray-500 text-xs">{{ comment.created_at|date:"Y-m-d H:i" }}</small>

--- a/comments/templates/comments/reply_item.html
+++ b/comments/templates/comments/reply_item.html
@@ -1,6 +1,6 @@
 <div class="reply-item bg-gray-100 rounded-md p-4 shadow-sm mt-4" id="reply-{{ comment.slug }}">
   <p class="text-gray-800">
-    <strong>{{ comment.account.username }}</strong>
+    <strong>{{ comment.account.profile.name }}</strong>
     : {{ comment.content }}
   </p>
   <small class="text-gray-500 text-xs">{{ comment.created_at|date:"Y-m-d H:i" }}</small>

--- a/projects/templates/projects/partials/comments_content.html
+++ b/projects/templates/projects/partials/comments_content.html
@@ -57,7 +57,7 @@
       <div class="flex-1">
         <div class="flex items-center justify-between mb-2">
           <div class="flex items-center">
-            <span class="font-medium text-gray-900">{{ comment.account.username }}</span>
+            <span class="font-medium text-gray-900">{{ comment.account.profile.name }}</span>
             <span class="text-sm text-gray-500 ml-2">{{ comment.created_at|date:"Y/m/d H:i" }}</span>
           </div>
         </div>
@@ -112,7 +112,7 @@
           {% for reply in comment.replies.all %}
           <div class="ml-8 bg-gray-50 rounded-lg p-4">
             <div class="flex items-center mb-2">
-              <span class="font-medium text-gray-900">{{ reply.account.username }}</span>
+              <span class="font-medium text-gray-900">{{ reply.account.profile.name }}</span>
               <span class="text-sm text-gray-500 ml-2">{{ reply.created_at|date:"Y/m/d H:i" }}</span>
             </div>
             <div class="text-gray-700">

--- a/projects/templates/projects/public.html
+++ b/projects/templates/projects/public.html
@@ -220,7 +220,7 @@
             <div class="space-y-4">
               <div>
                 <p class="text-sm text-gray-500">提案人</p>
-                <p class="text-sm font-medium text-gray-900">{{ project.account.username }}</p>
+                <p class="text-sm font-medium text-gray-900">{{ profile.name }}</p>
               </div>
               <div>
                 <p class="text-sm text-gray-500">募資時間</p>

--- a/projects/views.py
+++ b/projects/views.py
@@ -583,6 +583,9 @@ def public(request, slug):
     parent_ids = [category.parent_id for category in categories if category.parent_id]
     parent_categories = Category.objects.filter(id__in=parent_ids)
 
+    profile = project.account.profile
+    comments = project.comments.filter(parent__isnull=True).order_by("-created_at")
+
     return render(
         request,
         "projects/public.html",
@@ -595,6 +598,8 @@ def public(request, slug):
             "favorited": favorited,
             "categories": categories,
             "parent_categories": parent_categories,
+            "profile": profile,
+            "comments": comments,
         },
     )
 

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -37,7 +37,7 @@
           <div class="py-2">
             {% if user.is_authenticated %}
             <div class="px-4 py-2 text-center">
-              <span class="text-lg font-medium text-gray-900">{{ user.username }}</span>
+              <span class="text-lg font-medium text-gray-900">{{ user.profile.name }}</span>
             </div>
             <a href="{% url 'accounts:index' %}" class="block px-4 py-2 text-gray-800 hover:bg-teal-500 hover:text-white transition-colors duration-200">
               <i class="fas fa-user mr-2"></i>


### PR DESCRIPTION
#163 

原本user修改使用者名稱時，所有渲染畫面都還是顯示users.username，所以將以下位置修改成顯示profile.name:

- 留言
- 回覆留言
- 漢堡選單
- 專案提案人
- public頁面的留言區